### PR TITLE
Upgrade ycsb_run_test.sh command

### DIFF
--- a/lib/libiopstest
+++ b/lib/libiopstest
@@ -49,6 +49,7 @@ function libiopstest() {
           ycsb)
               TF_VAR_ycsb_security_group_name="${TF_VAR_ycsb_security_group_name}-${database}-${testId}"
               TF_VAR_ycsb_instance_name="${TF_VAR_ycsb_instance_name}-${database}-${testId}"
+              TF_VAR_ycsb_desired_workload="${workload}"
               ;;
       esac
    done

--- a/specs/ycsb/ycsb.env.sh
+++ b/specs/ycsb/ycsb.env.sh
@@ -10,3 +10,4 @@ export TF_VAR_ycsb_key_path=${iopstest_key_path}
 export TF_VAR_ycsb_instance_name="${iopstest_owner}-iopstest-ycsb"
 export TF_VAR_ycsb_security_group_name="${iopstest_owner}-iopstest-ycsb"
 
+export TF_VAR_ycsb_desired_workload=""

--- a/terraform-YCSB/ycsb_ec2.tf
+++ b/terraform-YCSB/ycsb_ec2.tf
@@ -109,7 +109,7 @@ resource "aws_instance" "ycsb" {
   provisioner "remote-exec" {
     inline = [
       "chmod u+x /home/${var.ycsb_username}/ycsb_run_test.sh",
-      "(/home/${var.ycsb_username}/ycsb_run_test.sh ${aws_instance.database.private_ip}) 2>&1 | tee /home/${var.ycsb_username}/ycsb_run_test.log"
+      "(/home/${var.ycsb_username}/ycsb_run_test.sh ${aws_instance.database.private_ip} ${var.ycsb_desired_workload}) 2>&1 | tee /home/${var.ycsb_username}/ycsb_run_test.log"
     ]
   }
 

--- a/terraform-YCSB/ycsb_variables.tf
+++ b/terraform-YCSB/ycsb_variables.tf
@@ -10,3 +10,4 @@ variable "ycsb_instance_name" { }
 variable "ycsb_aws_amis" { type = "map" }
 variable "ycsb_security_group_name" { }
 variable "ycsb_vpc_id" { } 
+variable "ycsb_desired_workload" { }

--- a/terraform-mongo/ycsb_run_test.sh
+++ b/terraform-mongo/ycsb_run_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 #
 # File: ycsb_run_test.sh
 # Description: provided by terraform-mongodb, provisioned by terraform-ycsb
@@ -11,13 +9,41 @@ set -x
 #   * update this example ycsb command to a real one based on test strategy
 #
 
+set -x
 
 datatase_private_id=$1
+desired_workload=$2
 
-sleep 10
+function check_readiness {
+
+   local is_ready=false
+   local is_connected=""
+
+   while [[ $is_ready == false ]]; do
+      is_connected=$(nc -zv -w 1 $datatase_private_id 27017 2>&1)
+      if [[ "$is_connected" == *succeeded* ]]; then
+         is_ready=true
+      else
+         echo "[$(date -u)] $is_connected"
+         echo "[$(date -u)] Waiting 1 second..."
+         sleep 1
+      fi  
+   done
+}
+
+check_readiness;
+
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+export YCSB_HOME=/home/ubuntu/ycsb-0.12.0
 
 ycsb load mongodb -s \
    -p mongodb.url="mongodb://${datatase_private_id}:27017/ycsb" \
-   -P /home/ubuntu/ycsb-0.12.0/workloads/workloada \
-   -p recordcount=1000 -threads 16 \
+   -P /home/ubuntu/ycsb-0.12.0/workloads/$desired_workload \
+   -threads 250 \
    -p mongodb.auth="false" 
+
+ycsb run mongodb -s \
+   -p mongodb.url="mongodb://${datatase_private_id}:27017/ycsb" \
+   -P /home/ubuntu/ycsb-0.12.0/workloads/$desired_workload \
+   -threads 250 \
+   -p mongodb.auth="false"


### PR DESCRIPTION
* Passes desired_workload from command line to ycsb_run_test.sh script
* Formalize mongodb ycsb_run_test.sh script
** adds ycsb load and run commands
** exports JAVA_HOME and YCSB_HOME environment
** receives the desired_workload from the command line

* Fixes the following error by exporting JAVA_HOME and YCSB_HOME environment variables in the YCSB run_test.sh script
```
aws_instance.ycsb (remote-exec): + ycsb load mongodb -s -p mongodb.url=mongodb://10.251.70.229:27017/ycsb -P /home/ubuntu/ycsb-0.12.0/workloads/workloada -p recordcount=1000 -threads 16 -p mongodb.auth=false
aws_instance.ycsb (remote-exec): grep: /usr/bin/bindings.properties: No such file or directory
aws_instance.ycsb (remote-exec): [ERROR] The specified binding 'mongodb' was not found.  Exiting.
```

Note
* ycsb_run_test.sh script should run automatically now