### PR TITLE
AI-56 Integrate DataDog into Database Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ export iopstest_subnet_id="subnet-456ghjk"
 $ export iopstest_aws_region="us-east-1"
 $ export iopstest_key_name="mykeyname
 $ export iopstest_key_path="/path/to/mykeyname.pem"
+
+$ export ioptest_datadog_api_key="..."  # optional
 ```
 
 Run a test

--- a/README.md
+++ b/README.md
@@ -12,10 +12,15 @@ Clone the repository
 $ git clone https://github.com/kenzanlabs/aws-iops-db.git
 ```
 
-Setup a site file
+Enter the project root diretcory
 
 ```
 $ cd aws-iops-db
+```
+
+Setup a site file
+
+```
 $ cat << EOF > iopstest-site
 #!/bin/bash
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,26 @@ bash iopstest $*
 EOF
 ```
 
-Run a test
+Basic syntax
 
 ```
-$ bash iopstest-site provision database test1
+$ bash iopstest-site provision database test1 test2 ... testN
+$ bash iopstest-site destroy database test1 test2 ... testN
 ```
 
-Destroy a test
+For Cassandra database
 
 ```
-$ bash iopstest-site destroy database test1
+$ bash iopstest-site provision cassandra test1, test2 ... testN
+$ bash iopstest-site destroy cassandra test1, test2 ... testN
+
+```
+
+For MongoDB database
+
+```
+$ bash iopstest-site provision mongodb test1 test2 ...  testN
+$ bash iopstest-site destroy mongodb test1 test2 ... testN
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -6,39 +6,53 @@
 
 ## Usage
 
-Setup Site Variables
+Clone the repository
 
 ```
-$ export AWS_CONFIG_FILE=...
-$ export AWS_DEFAULT_OUTPUT=json
-$ export AWS_DEFAULT_REGION=us-east-1
-$ export AWS_ACCESS_KEY=...
-$ export AWS_SECRET_KEY=...
+$ git clone https://github.com/kenzanlabs/aws-iops-db.git
+```
 
-$ export iopstest_owner="myname"
-$ export iopstest_vpc_id="vpc-abc1234"
-$ export iopstest_subnet_id="subnet-456ghjk"
-$ export iopstest_aws_region="us-east-1"
-$ export iopstest_key_name="mykeyname
-$ export iopstest_key_path="/path/to/mykeyname.pem"
+Setup a site file
 
-$ export ioptest_datadog_api_key="..."  # optional
+```
+$ cd aws-iops-db
+$ cat << EOF > iopstest-site
+#!/bin/bash
+
+export AWS_DEFAULT_OUTPUT=json
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY=...
+export AWS_SECRET_KEY=...
+
+export iopstest_owner="myname"
+export iopstest_vpc_id="vpc-abc1234"
+export iopstest_subnet_id="subnet-456ghjk"
+export iopstest_aws_region="${AWS_DEFAULT_REGION}"
+export iopstest_key_name="awspemkey"
+export iopstest_key_path="/absolute/path/to/awspemkey"
+
+export iopstest_datadog_api_key=""  # optional
+
+bash iopstest $*
+EOF
 ```
 
 Run a test
 
 ```
-$ git clone https://github.com/kenzanlabs/aws-iops-db.git
-$ cd aws-iops-blog/
-
-$ bash iopstest provision database test1,test2 # partial implemented
+$ bash iopstest-site provision database test1
 ```
 
-Destory a test
+Destroy a test
 
 ```
-$ bash iopstest destroy database test1
+$ bash iopstest-site destroy database test1
 ```
+
+## Notes
+
+* To rerun a test, destroy before provision
+
 ## References
 
 * https://github.com/terraform-community-modules/

--- a/lib/libiopstest
+++ b/lib/libiopstest
@@ -22,10 +22,6 @@ function libiopstest() {
 
    local ASSEMBLY="common machine $machine $database ycsb"
 
-#   if [[ ! -z $ioptest_datadog_api_key ]]; then
-#      ASSEMBLY="common machine $machine $datadog $database ycsb"
-#   fi
-
    #
    # load the environment for any action
    #

--- a/lib/libiopstest
+++ b/lib/libiopstest
@@ -14,9 +14,17 @@ function libiopstest() {
    local workspace="${workspace_root}/${database}/${testId}"
 
    local wkdir
+   cd $IOPSTEST_ROOT
+
+   #
+   # configure assembly components
+   #
+
    local ASSEMBLY="common machine $machine $database ycsb"
 
-   cd $IOPSTEST_ROOT
+#   if [[ ! -z $ioptest_datadog_api_key ]]; then
+#      ASSEMBLY="common machine $machine $datadog $database ycsb"
+#   fi
 
    #
    # load the environment for any action

--- a/specs/common/common.env.sh
+++ b/specs/common/common.env.sh
@@ -8,3 +8,4 @@ export TF_VAR_common_subnet_id=${iopstest_subnet_id}
 export TF_VAR_common_key_name=${iopstest_key_name}
 export TF_VAR_common_key_path=${iopstest_key_path}
 
+export TF_VAR_datadog_api_key=${ioptest_datadog_api_key}

--- a/specs/common/common.env.sh
+++ b/specs/common/common.env.sh
@@ -8,4 +8,4 @@ export TF_VAR_common_subnet_id=${iopstest_subnet_id}
 export TF_VAR_common_key_name=${iopstest_key_name}
 export TF_VAR_common_key_path=${iopstest_key_path}
 
-export TF_VAR_datadog_api_key=${ioptest_datadog_api_key}
+export TF_VAR_datadog_api_key=${iopstest_datadog_api_key}

--- a/specs/datadog/datadog.env.sh
+++ b/specs/datadog/datadog.env.sh
@@ -1,0 +1,1 @@
+export TF_VAR_datadog_api_key=${ioptest_datadog_api_key}

--- a/specs/datadog/datadog.env.sh
+++ b/specs/datadog/datadog.env.sh
@@ -1,1 +1,1 @@
-export TF_VAR_datadog_api_key=${ioptest_datadog_api_key}
+export TF_VAR_datadog_api_key=${iopstest_datadog_api_key}

--- a/specs/machine/machine2.env.sh
+++ b/specs/machine/machine2.env.sh
@@ -1,4 +1,4 @@
-export TF_VAR_machine_instance_name="ioptest (machine2) (r4.4xlarge 10K io1)"
+export TF_VAR_machine_instance_name="iopstest (machine2) (r4.4xlarge 10K io1)"
 export TF_VAR_machine_instance_type="r4.4xlarge"
 export TF_VAR_machine_security_group_name=$TF_VAR_machine_instance_name
 

--- a/specs/mongodb/mongodb.auto.tfvars
+++ b/specs/mongodb/mongodb.auto.tfvars
@@ -1,4 +1,4 @@
-mongodb_basedir = "/opt/mongodb"
+mongodb_basedir = "/data/mongodb"
 mongodb_conf_logpath = "/var/log/mongodb/mongod.log"
 mongodb_conf_engine = "/etc/mongod.conf"
 mongodb_username = "ubuntu"

--- a/terraform-common/datadog_install.sh
+++ b/terraform-common/datadog_install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DATADOG_API_KEY="$1"
+
+if [[ "x$DATADOG_API_KEY" != "x" ]]; then
+sudo apt-get update
+sudo apt-get install apt-transport-https
+
+sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
+sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+
+sudo apt-get update
+sudo apt-get install datadog-agent
+
+sudo sh -c "sed 's/api_key:.*/api_key: $DATADOG_API_KEY/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+
+echo "export DD_PROCESS_AGENT_ENABLED=true" | tee -a /etc/profile.d/datadog_profile.sh
+sudo /etc/init.d/datadog-agent start
+
+ps -ef | grep datadog
+
+fi

--- a/terraform-common/datadog_install.sh
+++ b/terraform-common/datadog_install.sh
@@ -3,20 +3,36 @@
 DATADOG_API_KEY="$1"
 
 if [[ "x$DATADOG_API_KEY" != "x" ]]; then
-sudo apt-get update
-sudo apt-get install apt-transport-https
 
-sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
-sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
+   #
+   # install the agent
+   #
 
-sudo apt-get update
-sudo apt-get install datadog-agent
+   sudo apt-get update
+   sudo apt-get install apt-transport-https
 
-sudo sh -c "sed 's/api_key:.*/api_key: $DATADOG_API_KEY/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+   sudo sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
+   sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52
 
-echo "export DD_PROCESS_AGENT_ENABLED=true" | tee -a /etc/profile.d/datadog_profile.sh
-sudo /etc/init.d/datadog-agent start
+   sudo apt-get update
+   sudo apt-get install datadog-agent
 
-ps -ef | grep datadog
+   #
+   # configure the service
+   #
+   #   Config File                         | Description
+   #   --------------------------------------------------------------
+   #   /etc/dd-agent/datadog.conf.example  | configures the external DD service recieving agent data
+   #   /etc/dd-agent/conf.d/*example       | configures the internal database receiving agent data
+   #
 
+   sudo sh -c "sed 's/api_key:.*/api_key: $DATADOG_API_KEY/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+
+   #
+   # start the service
+   #
+
+   echo "export DD_PROCESS_AGENT_ENABLED=true" | tee -a /etc/profile.d/datadog_profile.sh
+   sudo /etc/init.d/datadog-agent start
+   ps -ef | grep datadog
 fi

--- a/terraform-common/datadog_variables.tf
+++ b/terraform-common/datadog_variables.tf
@@ -1,0 +1,1 @@
+variable "datadog_api_key" {}

--- a/terraform-machine/machine_ec2.tf
+++ b/terraform-machine/machine_ec2.tf
@@ -48,4 +48,49 @@ resource "aws_instance" "database" {
     }
   }
 
+  /**
+   * create /tmp/provisioning
+   */
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /tmp/provisioning",
+      "sudo chown -R ${var.common_username}:${var.common_username} /tmp/provisioning/"
+    ]
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
+  /**
+   * datadog client
+   */
+
+  provisioner "file" {
+    source = "datadog_install.sh"
+    destination = "/tmp/provisioning/datadog_install.sh"
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chmod ugo+x /tmp/provisioning/datadog_install.sh",
+      "sudo /tmp/provisioning/datadog_install.sh ${var.datadog_api_key}",
+    ]
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
 }

--- a/terraform-machine4/machine_ec2.tf
+++ b/terraform-machine4/machine_ec2.tf
@@ -46,4 +46,49 @@ resource "aws_instance" "database" {
     private_key = "${var.common_key_path}"
   }
 
+  /**
+   * create /tmp/provisioning
+   */
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /tmp/provisioning",
+      "sudo chown -R ${var.common_username}:${var.common_username} /tmp/provisioning/"
+    ]
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
+  /**
+   * datadog client
+   */
+
+  provisioner "file" {
+    source = "datadog_install.sh"
+    destination = "/tmp/provisioning/datadog_install.sh"
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chmod ugo+x /tmp/provisioning/datadog_install.sh",
+      "sudo /tmp/provisioning/datadog_install.sh ${var.datadog_api_key}",
+    ]
+    connection {
+      type = "ssh"
+      host = "${aws_instance.database.public_ip}"
+      user = "${var.common_username}"
+      private_key = "${file("${var.common_key_path}")}"
+    }
+  }
+
 }

--- a/terraform-mongo/mgdb_install.sh
+++ b/terraform-mongo/mgdb_install.sh
@@ -16,7 +16,7 @@ DEVICE_NAME=xvdh
 
 #now provided by terraform
 #mongodb_version="3.6.0"
-#mongodb_basedir="/opt/mongodb"
+#mongodb_basedir="/data/mongodb"
 #mongodb_conf_engine="/etc/mongod.conf"
 #mongodb_conf_logpath="/var/log/mongodb/mongod.log"
 

--- a/terraform-mongo/mgdb_system.sh
+++ b/terraform-mongo/mgdb_system.sh
@@ -8,10 +8,10 @@
 set -x
 
 #
-# mount /opt
+# mount /data
 #
 
-mkdir -p /opt
+mkdir -p /data
 
 device_name=xvdh
 if [[ -b /dev/nvme0n1 ]]; then
@@ -31,14 +31,14 @@ if [[ -b /dev/nvme0n1 ]]; then
       time mkfs.xfs -K -L opt /dev/md0   # use -K to avoid the wait time, mkfs.xfs has to process 3538.78 of 3799.73 GB NVMe
       mdadm --detail --scan | sudo tee -a /etc/mdadm.conf
       #sudo dracut -H -f /boot/initramfs-$(uname -r).img $(uname -r) # deferring for now dracut is not available for xenial via apt-get
-      mount /dev/md0 /opt
-      echo "/dev/md0 /opt xfs defaults 0 0" | tee -a /etc/fstab
+      mount /dev/md0 /data
+      echo "/dev/md0 /data xfs defaults 0 0" | tee -a /etc/fstab
       device_name=md0
    fi
 fi
 
-mount /dev/${device_name} /opt
-echo "/dev/${device_name} /opt xfs defaults 0 0" | sudo tee -a /etc/fstab
+mount /dev/${device_name} /data
+echo "/dev/${device_name} /data xfs defaults 0 0" | sudo tee -a /etc/fstab
 
 #
 # tuning for mongo

--- a/terraform-mongo/mgdb_templates/mgdb_install.sh
+++ b/terraform-mongo/mgdb_templates/mgdb_install.sh
@@ -17,7 +17,7 @@ DEVICE_NAME=xvdh
 
 #now provided by terraform
 #mongodb_version="3.6.0"
-#mongodb_basedir="/opt/mongodb"
+#mongodb_basedir="/data/mongodb"
 #mongodb_conf_engine="/etc/mongod.conf"
 #mongodb_conf_logpath="/var/log/mongodb/mongod.log"
 


### PR DESCRIPTION
* Moves mongodb data directory from /opt to /data (see commit 6eac993)
* Integrates Data Dog agent (optionally)
* Update README to include clearer instructions
* Corrects a number of typos

Note: update iopstest-site file to use 
```
export iopstest_datadog_api_key="..."   # note spelling is corrected to include 's'
```